### PR TITLE
Quadtree optimizations

### DIFF
--- a/SnoBros2/Game.m
+++ b/SnoBros2/Game.m
@@ -94,7 +94,7 @@
 - (void)step {
   [entityManager_ update];
   
-  //[collisionSystem_     update];
+  [collisionSystem_     update];
   [movementSystem_      update];
   [enemyBehaviorSystem_ update];
   [renderSystem_ update];

--- a/SnoBros2/Systems/CollisionSystem.h
+++ b/SnoBros2/Systems/CollisionSystem.h
@@ -20,7 +20,6 @@
 - (id)initWithEntityManager:(EntityManager *)entityManager;
 
 - (void)update;
-- (void)checkCollisionsFor:(Entity *)entity;
 - (bool)didEntity:(Entity *)entity collideWith:(Entity *)other;
 
 @end

--- a/SnoBros2/Systems/CollisionSystem.m
+++ b/SnoBros2/Systems/CollisionSystem.m
@@ -44,25 +44,28 @@
     [quadtree_ addObject:entity withBoundingBox:collision.boundingBox];
   }
 
-  for (Entity *entity in entities) {
-    [self checkCollisionsFor:entity];
-  }
-}
+  NSArray *collisionGroups = [quadtree_ retrieveCollisionGroups];
+  for (NSArray *group in collisionGroups) {
+    for (int i = 0; i < group.count; i++) {
+      for (int j = i; j < group.count; j++) {
+        Entity *entity = group[i];
+        Entity *other  = group[j];
 
+        if ([self didEntity:entity collideWith:other]) {
 
+          NSString *name = [entity.uuid stringByAppendingString:@"|collidedWith"];
+          NSDictionary *data = @{@"otherEntity": other};
+          [[NSNotificationCenter defaultCenter] postNotificationName:name
+                                                              object:self
+                                                            userInfo:data];
 
-- (void)checkCollisionsFor:(Entity *)entity {
-  Collision *collision   = [entity getComponentByString:@"Collision"];
-
-  NSArray *otherEntities = [quadtree_ retrieveObjectsNear:collision.boundingBox];
-
-  for (Entity *other in otherEntities) {
-    if ([self didEntity:entity collideWith:other]) {
-      NSString *name = [entity.uuid stringByAppendingString:@"|collidedWith"];
-      NSDictionary *data = @{@"otherEntity": other};
-      [[NSNotificationCenter defaultCenter] postNotificationName:name
-                                                          object:self
-                                                        userInfo:data];
+          NSString *otherName = [other.uuid stringByAppendingString:@"|collidedWith"];
+          NSDictionary *otherData = @{@"otherEntity": entity};
+          [[NSNotificationCenter defaultCenter] postNotificationName:otherName
+                                                              object:self
+                                                            userInfo:otherData];
+        }
+      }
     }
   }
 }

--- a/SnoBros2/Utilities/Quadtree.h
+++ b/SnoBros2/Utilities/Quadtree.h
@@ -44,10 +44,10 @@ enum quadrant { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT };
 - (void)split;
 - (bool)isLeafNode;
 - (bool)isNotLeafNode;
-- (void)subdivideRectangle;
 - (void)redistributeObjects;
 - (void)addObject:(id)object withBoundingBox:(BoundingBox *)boundingBox;
 - (NSArray *)nodesContainingBoundingBox:(BoundingBox *)boundingBox;
 - (NSArray *)retrieveObjectsNear:(BoundingBox *)boundingBox;
+- (NSArray *)retrieveCollisionGroups;
 
 @end

--- a/SnoBros2/Utilities/Quadtree.m
+++ b/SnoBros2/Utilities/Quadtree.m
@@ -26,8 +26,6 @@
     maxObjects_ = maxObjects;
     maxLevels_  = maxLevels;
     objects_    = [[NSMutableArray alloc] init];
-
-    [self subdivideRectangle];
   }
   return self;
 }
@@ -43,7 +41,17 @@
 
 
 
-- (void)subdivideRectangle {
+- (void)clear {
+  [objects_ removeAllObjects];
+  for (int i = 0; i < NUM_NODES; i++) {
+    [nodes_[i] clear];
+    nodes_[i] = NULL;
+  }
+}
+
+
+
+- (void)split {
   float  x = bounds_.x;
   float  y = bounds_.y;
 
@@ -68,21 +76,7 @@
                                               Y:y - quarterHeight
                                           width:halfWidth
                                          height:halfHeight];
-}
 
-
-
-- (void)clear {
-  [objects_ removeAllObjects];
-  for (int i = 0; i < NUM_NODES; i++) {
-    [nodes_[i] clear];
-    nodes_[i] = NULL;
-  }
-}
-
-
-
-- (void)split {
   nodes_[TOP_LEFT]     = [[Quadtree alloc] initWithBounds:topLeft_
                                                     level:level_ + 1
                                                maxObjects:maxObjects_
@@ -158,6 +152,28 @@
     }
   }
   [objects_ removeAllObjects];
+}
+
+
+
+- (NSArray *)retrieveCollisionGroups {
+  NSMutableArray *found = [[NSMutableArray alloc] initWithCapacity:1024];
+
+  if ([self isLeafNode]) {
+    NSMutableArray *group = [[NSMutableArray alloc] initWithCapacity:15];
+    for (NSDictionary *entry in objects_) {
+      [group addObject:entry[@"object"]];
+    }
+    [found addObject:group];
+    return found;
+  }
+
+
+  for (int i = 0; i < NUM_NODES; i++) {
+    [found addObjectsFromArray:[nodes_[i] retrieveCollisionGroups]];
+  }
+
+  return found;
 }
 
 


### PR DESCRIPTION
Perform collision detection on collision groups in leaves of the
quadtree rather than traversing the tree for every entity. Subdivide the
bounding box when splitting the tree.
